### PR TITLE
Organize features into domain folders

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,0 +1,3 @@
+import LoginPage from '@/features/auth/pages/LoginPage';
+
+export default LoginPage;

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -1,0 +1,3 @@
+import MessagesPage from '@/features/messaging/pages/MessagesPage';
+
+export default MessagesPage;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,21 @@
-import Image from "next/image";
+import Link from 'next/link';
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="list-inside list-decimal text-sm/6 text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-[family-name:var(--font-geist-mono)] font-semibold">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    <main className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Welcome</h1>
+      <ul className="list-disc list-inside space-y-2">
+        <li>
+          <Link href="/auth/login" className="text-blue-600 underline">
+            Login
+          </Link>
+        </li>
+        <li>
+          <Link href="/messages" className="text-blue-600 underline">
+            Messages
+          </Link>
+        </li>
+      </ul>
+    </main>
   );
 }

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useState } from 'react';
+import { useAuth } from '../hooks/useAuth';
+
+export default function LoginForm() {
+  const { user, login } = useAuth();
+  const [name, setName] = useState('');
+
+  if (user) {
+    return <p>Welcome, {user}!</p>;
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    login(name);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2">
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Username"
+        className="border px-2 py-1 rounded"
+      />
+      <button type="submit" className="px-2 py-1 border rounded">
+        Login
+      </button>
+    </form>
+  );
+}

--- a/src/features/auth/hooks/useAuth.ts
+++ b/src/features/auth/hooks/useAuth.ts
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+export function useAuth() {
+  const [user, setUser] = useState<string | null>(null);
+
+  const login = (name: string) => {
+    setUser(name);
+  };
+
+  const logout = () => {
+    setUser(null);
+  };
+
+  return { user, login, logout };
+}

--- a/src/features/auth/pages/LoginPage.tsx
+++ b/src/features/auth/pages/LoginPage.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import LoginForm from '../components/LoginForm';
+
+export default function LoginPage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold mb-4">Login</h1>
+      <LoginForm />
+    </main>
+  );
+}

--- a/src/features/messaging/components/MessageList.tsx
+++ b/src/features/messaging/components/MessageList.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useState } from 'react';
+import { useMessages } from '../hooks/useMessages';
+
+export default function MessageList() {
+  const { messages, addMessage } = useMessages();
+  const [input, setInput] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim()) return;
+    addMessage(input.trim());
+    setInput('');
+  };
+
+  return (
+    <div>
+      <form onSubmit={handleSubmit} className="flex gap-2 mb-4">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type a message"
+          className="border px-2 py-1 rounded flex-1"
+        />
+        <button type="submit" className="px-2 py-1 border rounded">
+          Send
+        </button>
+      </form>
+      <ul className="space-y-2">
+        {messages.map((m) => (
+          <li key={m.id} className="border-b pb-1">
+            {m.text}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/messaging/hooks/useMessages.ts
+++ b/src/features/messaging/hooks/useMessages.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+export interface Message {
+  id: number;
+  text: string;
+}
+
+export function useMessages() {
+  const [messages, setMessages] = useState<Message[]>([]);
+
+  const addMessage = (text: string) => {
+    setMessages((prev) => [...prev, { id: Date.now(), text }]);
+  };
+
+  return { messages, addMessage };
+}

--- a/src/features/messaging/pages/MessagesPage.tsx
+++ b/src/features/messaging/pages/MessagesPage.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import MessageList from '../components/MessageList';
+
+export default function MessagesPage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold mb-4">Messages</h1>
+      <MessageList />
+    </main>
+  );
+}

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -1,0 +1,12 @@
+# Project Tasks
+
+This folder tracks high level tasks for each feature domain.
+
+## Auth
+- [ ] Implement basic login form
+- [ ] Manage authenticated user state
+
+## Messaging
+- [ ] Display a list of messages
+- [ ] Allow adding new messages
+

--- a/tasks/auth.md
+++ b/tasks/auth.md
@@ -1,0 +1,4 @@
+# Auth Feature Tasks
+
+- [ ] Add persistent authentication
+- [ ] Connect login form to backend API

--- a/tasks/messaging.md
+++ b/tasks/messaging.md
@@ -1,0 +1,4 @@
+# Messaging Feature Tasks
+
+- [ ] Persist messages to backend
+- [ ] Support real-time updates


### PR DESCRIPTION
## Summary
- add `features` directory with `auth` and `messaging` domains
- move login and messaging pages to feature folders
- create hooks and components for each feature
- adjust routing to import pages from feature folders
- trim default homepage and link to new routes
- track basic project tasks

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845b9160c0083258951ff5cfb41459a